### PR TITLE
Use public ip and monitoring with new launch config

### DIFF
--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -33,7 +33,11 @@ module Elbas
       end
 
       def create_options
-        { security_groups: base_ec2_instance.security_groups.to_a, detailed_instance_monitoring: false }
+        {
+          security_groups: base_ec2_instance.security_groups.to_a,
+          detailed_instance_monitoring: true,
+          associate_public_ip_address: true
+        }
       end
 
       def instance_size

--- a/lib/elbas/version.rb
+++ b/lib/elbas/version.rb
@@ -1,3 +1,3 @@
 module Elbas
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
I suppose it would be best if these were configuration options, but for now I think it's better if the new instances have public ip's (and why not monitoring?). Otherwise, if the group scales up and down it will terminate the original (public) instance and all you're left with is instances that don't have public IP's.
