### PR TITLE
Add aws_no_reboot_on_create_ami for integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ set :aws_access_key_id,     ENV['AWS_ACCESS_KEY_ID']
 set :aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY']
 set :aws_region,            ENV['AWS_REGION']
 
+set :aws_no_reboot_on_create_ami, true
 set :aws_autoscale_instance_size, 'm1.small'
 ```
 

--- a/lib/elbas/ami.rb
+++ b/lib/elbas/ami.rb
@@ -16,7 +16,7 @@ module Elbas
       @aws_counterpart = ec2.images.create \
         name: name,
         instance_id: base_ec2_instance.id,
-        no_reboot: true
+        no_reboot: fetch(:aws_no_reboot_on_create_ami, true)
     end
 
     def destroy(images = [])


### PR DESCRIPTION
I want to change no_reboot option when creating ami.
When no_reboot is true, file system integrity is not guaranteed.
