### PR TITLE
Explicitly specify aws-sdk version 1 in gemspec and in require

### DIFF
--- a/elbas.gemspec
+++ b/elbas.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
 
-  spec.add_dependency 'aws-sdk', '~> 1'
+  spec.add_dependency 'aws-sdk-v1'
   spec.add_dependency 'capistrano', '> 3.0.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'
 

--- a/lib/elbas.rb
+++ b/lib/elbas.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'capistrano/all'
 require 'active_support/concern'
 


### PR DESCRIPTION
if you use aws-sdk version 2 in your own application bundler complains about version incompatibility

Bundler could not find compatible versions for gem "aws-sdk":
  In Gemfile:
    elbas (~> 0.19.0) ruby depends on
      aws-sdk (~> 1) ruby

    aws-sdk (~> 2.1.19) ruby

So we can explicitly specify aws-sdk version 1in gemspec and elbas.rb file's require call