### PR TITLE
Custom tags for AMI's and launch configuration options

### DIFF
--- a/lib/elbas/ami.rb
+++ b/lib/elbas/ami.rb
@@ -13,12 +13,11 @@ module Elbas
 
     def save
       info "Creating EC2 AMI from EC2 Instance: #{base_ec2_instance.id}"
-      tag add_custom_tags
-
       @aws_counterpart = ec2.images.create \
         name: name,
         instance_id: base_ec2_instance.id,
         no_reboot: fetch(:aws_no_reboot_on_create_ami, true)
+      tag custom_tags
     end
 
     def destroy(images = [])
@@ -30,7 +29,7 @@ module Elbas
 
     private
 
-      def add_custom_tags
+      def custom_tags
         fetch(:aws_elbas_ami_custom_tags, {})
       end
 

--- a/lib/elbas/ami.rb
+++ b/lib/elbas/ami.rb
@@ -13,6 +13,8 @@ module Elbas
 
     def save
       info "Creating EC2 AMI from EC2 Instance: #{base_ec2_instance.id}"
+      tag add_custom_tags
+
       @aws_counterpart = ec2.images.create \
         name: name,
         instance_id: base_ec2_instance.id,
@@ -27,6 +29,10 @@ module Elbas
     end
 
     private
+
+      def add_custom_tags
+        fetch(:aws_elbas_ami_custom_tags, {})
+      end
 
       def name
         timestamp "#{environment}-AMI"

--- a/lib/elbas/aws_resource.rb
+++ b/lib/elbas/aws_resource.rb
@@ -29,6 +29,7 @@ module Elbas
         "#{str}-#{Time.now.to_i}"
       end
 
+
     private
 
       def deployed_with_elbas?(resource)

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -42,7 +42,7 @@ module Elbas
         fetch(:aws_autoscale_detailed_instance_monitoring, false)
       end
 
-      def key_pair
+      def aws_key_pair
         fetch(:aws_autoscale_key_pair, nil)
       end
 
@@ -51,17 +51,18 @@ module Elbas
         _options = {
           security_groups: base_ec2_instance.security_groups.to_a,
           detailed_instance_monitoring: detailed_instance_monitoring,
-          associate_public_ip_address: true,
+          associate_public_ip_address: true
         }
 
         if user_data = fetch(:aws_launch_configuration_user_data, nil)
           _options.merge user_data: user_data
         end
 
-        if key_pair = key_pair
-          _options.merge key_pair: key_pair
+        unless aws_key_pair.nil?
+          _options.merge key_pair: aws_key_pair
         end
-        info "autoscaling launch_configurations_options #{_options}"
+        debug "autoscaling key_pair #{key_pair}"
+        debug "autoscaling launch_configurations_options #{_options}"
         _options
       end
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -61,8 +61,6 @@ module Elbas
         unless aws_key_pair.nil?
           _options[:key_pair] = aws_key_pair
         end
-        info "autoscaling key_pair #{aws_key_pair}"
-        info "autoscaling launch_configurations_options #{_options}"
         _options
       end
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -38,10 +38,15 @@ module Elbas
         fetch(:aws_autoscale_instance_size, 'm1.small')
       end
 
+      def detailed_instance_monitoring
+        fetch(:aws_detailed_instance_monitoring, false)
+      end
+
+
       def create_options
         _options = {
           security_groups: base_ec2_instance.security_groups.to_a,
-          detailed_instance_monitoring: true,
+          detailed_instance_monitoring: detailed_instance_monitoring,
           associate_public_ip_address: true,
         }
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -61,7 +61,7 @@ module Elbas
         unless aws_key_pair.nil?
           _options.merge key_pair: aws_key_pair
         end
-        debug "autoscaling key_pair #{key_pair}"
+        debug "autoscaling key_pair #{aws_key_pair}"
         debug "autoscaling launch_configurations_options #{_options}"
         _options
       end

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -61,8 +61,8 @@ module Elbas
         unless aws_key_pair.nil?
           _options.merge key_pair: aws_key_pair
         end
-        debug "autoscaling key_pair #{aws_key_pair}"
-        debug "autoscaling launch_configurations_options #{_options}"
+        info "autoscaling key_pair #{aws_key_pair}"
+        info "autoscaling launch_configurations_options #{_options}"
         _options
       end
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -59,7 +59,7 @@ module Elbas
         end
 
         unless aws_key_pair.nil?
-          _options[:key_pair] aws_key_pair
+          _options[:key_pair] = aws_key_pair
         end
         info "autoscaling key_pair #{aws_key_pair}"
         info "autoscaling launch_configurations_options #{_options}"

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -61,6 +61,7 @@ module Elbas
         if key_pair = key_pair
           _options.merge key_pair: key_pair
         end
+        info "autoscaling launch_configurations_options #{_options}"
         _options
       end
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -42,6 +42,10 @@ module Elbas
         fetch(:aws_detailed_instance_monitoring, false)
       end
 
+      def key_pair
+        fetch(:aws_key_pair, nil)
+      end
+
 
       def create_options
         _options = {
@@ -52,6 +56,10 @@ module Elbas
 
         if user_data = fetch(:aws_launch_configuration_user_data, nil)
           _options.merge user_data: user_data
+        end
+
+        if user_data = key_pair
+          _options.merge key_pair: key_pair
         end
 
         _options

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -39,11 +39,11 @@ module Elbas
       end
 
       def detailed_instance_monitoring
-        fetch(:aws_detailed_instance_monitoring, false)
+        fetch(:aws_autoscale_detailed_instance_monitoring, false)
       end
 
       def key_pair
-        fetch(:aws_key_pair, nil)
+        fetch(:aws_autoscale_key_pair, nil)
       end
 
 
@@ -58,10 +58,9 @@ module Elbas
           _options.merge user_data: user_data
         end
 
-        if user_data = key_pair
+        if key_pair = key_pair
           _options.merge key_pair: key_pair
         end
-
         _options
       end
 

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -59,7 +59,7 @@ module Elbas
         end
 
         unless aws_key_pair.nil?
-          _options.merge key_pair: aws_key_pair
+          _options[:key_pair] aws_key_pair
         end
         info "autoscaling key_pair #{aws_key_pair}"
         info "autoscaling launch_configurations_options #{_options}"

--- a/lib/elbas/version.rb
+++ b/lib/elbas/version.rb
@@ -1,3 +1,3 @@
 module Elbas
-  VERSION = '0.20.3'
+  VERSION = '0.21.3'
 end

--- a/lib/elbas/version.rb
+++ b/lib/elbas/version.rb
@@ -1,3 +1,3 @@
 module Elbas
-  VERSION = '0.20.1'
+  VERSION = '0.20.2'
 end

--- a/lib/elbas/version.rb
+++ b/lib/elbas/version.rb
@@ -1,3 +1,3 @@
 module Elbas
-  VERSION = '0.20.0'
+  VERSION = '0.20.1'
 end

--- a/lib/elbas/version.rb
+++ b/lib/elbas/version.rb
@@ -1,3 +1,3 @@
 module Elbas
-  VERSION = '0.20.2'
+  VERSION = '0.20.3'
 end


### PR DESCRIPTION
 Additional launch configuration optionss can be specified through parameters ej:

```
set :aws_autoscale_key_pair, 'key-name'
set :detailed_instance_monitoring, true
```

Support for custom tags on AMI's creation,  via aws_elbas_ami_custom_tags parameter, ej:
`
set :aws_elbas_ami_custom_tags, {'Application' => 'app-production'}
`
