### PR TITLE
add in ability for multiple autoscaling environments

### DIFF
--- a/lib/elbas/ami.rb
+++ b/lib/elbas/ami.rb
@@ -29,7 +29,7 @@ module Elbas
     private
 
       def name
-        timestamp "#{environment}-AMI"
+        timestamp "ELBAS-#{environment}-#{$server_role}-AMI"
       end
 
       def trash

--- a/lib/elbas/aws_resource.rb
+++ b/lib/elbas/aws_resource.rb
@@ -32,7 +32,7 @@ module Elbas
     private
 
       def deployed_with_elbas?(resource)
-        resource.tags['Deployed-with'] == 'ELBAS'
+        resource.name =~ /ELBAS-#{environment}-#{$server_role}/
       end
 
   end

--- a/lib/elbas/capistrano.rb
+++ b/lib/elbas/capistrano.rb
@@ -12,6 +12,8 @@ def autoscale(groupname, *args)
 
   set :aws_autoscale_group, groupname
 
+  $server_role = args.first[:roles].first.to_s
+
   running_instances.each do |instance|
     hostname = instance.dns_name || instance.private_ip_address
     p "ELBAS: Adding server: #{hostname}"

--- a/lib/elbas/launch_configuration.rb
+++ b/lib/elbas/launch_configuration.rb
@@ -31,7 +31,7 @@ module Elbas
     private
 
       def name
-        timestamp "ELBAS-#{environment}-LC"
+        timestamp "ELBAS-#{environment}-#{$server_role}-LC"
       end
 
       def instance_size
@@ -41,8 +41,8 @@ module Elbas
       def create_options
         _options = {
           security_groups: base_ec2_instance.security_groups.to_a,
-          detailed_instance_monitoring: fetch(:aws_launch_configuration_detailed_instance_monitoring, true),
-          associate_public_ip_address: fetch(:aws_launch_configuration_associate_public_ip, true),
+          detailed_instance_monitoring: true,
+          associate_public_ip_address: true,
         }
 
         if user_data = fetch(:aws_launch_configuration_user_data, nil)
@@ -52,15 +52,10 @@ module Elbas
         _options
       end
 
-      def deployed_with_elbas?(lc)
-        lc.name =~ /ELBAS-#{environment}/
-      end
-
       def trash
         autoscaling.launch_configurations.to_a.select do |lc|
           deployed_with_elbas? lc
         end
       end
-
   end
 end


### PR DESCRIPTION
I have two groups of servers I want to be able to scale. Currently i have them in different environments for my capistrano deploy but I did not want to go back and overwrite my application image when deploying to my queue group.