### PR TITLE
Check existence of ami before deleting

### DIFF
--- a/lib/elbas/ami.rb
+++ b/lib/elbas/ami.rb
@@ -24,7 +24,7 @@ module Elbas
       images.each do |i|
         info "Deleting old AMI: #{i.id}"
         snapshots = snapshots_attached_to i
-        i.delete
+        i.delete if i.exists?
         delete_snapshots snapshots
       end
     end


### PR DESCRIPTION
I was getting "AWS::Core::Resource::NotFound: unable to find the image" when deleting the old AMI. This change only deletes the AMI if it exists.

```** Execute elbas:scale
"ELBAS: Creating EC2 AMI from EC2 Instance: i-xxxxxxxxx"
"ELBAS: Created AMI: ami-xxxxxxx"
"ELBAS: Creating an EC2 Launch Configuration for AMI: ami-xxxxxxxxxx"
"ELBAS: Created Launch Configuration: ELBAS-xxxxx"
"ELBAS: Attaching Launch Configuration to AutoScale Group"
"ELBAS: Deleting old launch configuration: ELBAS-xxxxxx"
"ELBAS: Deleting old AMI: ami-xxxxxx"
cap aborted!
AWS::Core::Resource::NotFound: unable to find the image
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/aws-sdk-v1-1.66.0/lib/aws/core/resource.rb:238:in `rescue in block in define_attribute_getter'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/aws-sdk-v1-1.66.0/lib/aws/core/resource.rb:234:in `block in define_attribute_getter'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/aws-sdk-v1-1.66.0/lib/aws/ec2/image.rb:172:in `block_device_mappings'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/ami.rb:43:in `delete_snapshots_attached_to'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/ami.rb:27:in `block in destroy'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/ami.rb:24:in `each'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/ami.rb:24:in `destroy'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/aws_resource.rb:14:in `cleanup'
/Users/dave/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/elbas-0.26.0/lib/elbas/ami.rb:7:in `create'
```