### PR TITLE
fix no launch template error for fleet composition

### DIFF
--- a/lib/elbas/aws/autoscale_group.rb
+++ b/lib/elbas/aws/autoscale_group.rb
@@ -17,12 +17,13 @@ module Elbas
       end
 
       def launch_template
-        raise Elbas::Errors::NoLaunchTemplate unless aws_counterpart.launch_template
+        lts = launch_template_specification
+        raise Elbas::Errors::NoLaunchTemplate unless lts
 
         LaunchTemplate.new(
-          aws_counterpart.launch_template.launch_template_id,
-          aws_counterpart.launch_template.launch_template_name,
-          aws_counterpart.launch_template.version,
+          lts.launch_template_id,
+          lts.launch_template_name,
+          lts.version
         )
       end
 
@@ -38,6 +39,13 @@ module Elbas
             .first
         end
 
+        def launch_template_specification
+          aws_counterpart.launch_template ||
+            aws_counterpart.mixed_instances_policy.launch_template
+            .launch_template_specification
+        rescue NoMethodError
+          raise Elbas::Errors::NoLaunchTemplate
+        end
     end
   end
 end


### PR DESCRIPTION
when autoscaling group fleet composition is set to combine purchase options
and instances, aws_counterpart.launch_template is nil, so needs to get it
from aws_counterpart.mixed_instances_policy instead.