### PR TITLE
fix no launch template error for fleet composition

### DIFF
--- a/lib/elbas/aws/autoscale_group.rb
+++ b/lib/elbas/aws/autoscale_group.rb
@@ -17,12 +17,13 @@ module Elbas
       end
 
       def launch_template
-        raise Elbas::Errors::NoLaunchTemplate unless aws_counterpart.launch_template
+        lts = aws_launch_template || aws_launch_template_specification
+        raise Elbas::Errors::NoLaunchTemplate unless lts
 
         LaunchTemplate.new(
-          aws_counterpart.launch_template.launch_template_id,
-          aws_counterpart.launch_template.launch_template_name,
-          aws_counterpart.launch_template.version,
+          lts.launch_template_id,
+          lts.launch_template_name,
+          lts.version
         )
       end
 
@@ -38,6 +39,14 @@ module Elbas
             .first
         end
 
+        def aws_launch_template
+          aws_counterpart.launch_template
+        end
+
+        def aws_launch_template_specification
+          aws_counterpart.mixed_instances_policy&.launch_template
+            &.launch_template_specification
+        end
     end
   end
 end

--- a/spec/aws/autoscale_group_spec.rb
+++ b/spec/aws/autoscale_group_spec.rb
@@ -48,6 +48,20 @@ describe Elbas::AWS::AutoscaleGroup do
       expect(subject.launch_template.version).to eq '$Latest'
     end
 
+    it 'returns a LauchTemplate object for fleet composition' do
+      allow(subject.aws_counterpart).to receive(:launch_template) { nil }
+      allow(subject.aws_counterpart).to receive_message_chain(
+        :mixed_instances_policy, :launch_template,
+        :launch_template_specification) do
+        double(launch_template_id: 'test-2',
+               launch_template_name: 'mixed_instance',
+               version: '$Latest')
+      end
+
+      expect(subject.launch_template.id).to eq 'test-2'
+      expect(subject.launch_template.name).to eq 'mixed_instance'
+      expect(subject.launch_template.version).to eq '$Latest'
+    end
 
   end
 end


### PR DESCRIPTION
when autoscaling group fleet composition is set to combine purchase options
and instances, aws_counterpart.launch_template is nil, so needs to get it
from aws_counterpart.mixed_instances_policy instead.