### PR TITLE
Keep Old Versions of AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ set :aws_secret_key, ENV['AWS_SECRET_ACCESS_KEY']
 set :aws_region,     ENV['AWS_REGION']
 ```
 
+Define how many past AMIs to keep during cleanup. The default is 5.
+
+```ruby
+set :elbas_keep_amis, 5
+```
+
 ## Usage
 
 Instead of using Capistrano's `server` method, use `autoscale` instead in

--- a/lib/elbas/tasks/elbas.rake
+++ b/lib/elbas/tasks/elbas.rake
@@ -25,9 +25,14 @@ namespace :elbas do
     info "Updated launch template, new default version = #{launch_template.version}"
 
     info "Cleaning up old AMIs..."
-    ami.ancestors.each do |ancestor|
-      info "Deleting old AMI: #{ancestor.id}"
-      ancestor.delete
+    keep = fetch(:elbas_keep_amis) || 5
+    if ami.ancestors.count > keep
+      amis = ami.ancestors.drop(keep)
+      amis.each do |ancestor|
+        info "Deleting old AMI: #{ancestor.id}"
+        ancestor.delete
+      end
+      info "Deleted #{amis.count} old AMIs and keeping newest #{keep}"
     end
 
     info "Deployment complete!"


### PR DESCRIPTION
Adding the "elbas_keep_amis" variable which defines how many old AMIs to keep during cleanup. Fixes #40 