### PR TITLE
Configurable Hostname Communication Type (Public/Private DNS/IP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ set :aws_secret_key, ENV['AWS_SECRET_ACCESS_KEY']
 set :aws_region,     ENV['AWS_REGION']
 ```
 
+Set the means through which to communicate with instances. Select from `public_dns_name` *(the default)*, `public_ip_address`, `private_dns_name` and `private_ip_address`. For example, if you are using a bastion host and SSHing into your instances via a private subnet you would want to add the following:
+
+```ruby
+set :elbas_hostname_type, 'private_ip_address'
+```
+
 ## Usage
 
 Instead of using Capistrano's `server` method, use `autoscale` instead in

--- a/lib/elbas/aws/base.rb
+++ b/lib/elbas/aws/base.rb
@@ -3,6 +3,9 @@ module Elbas
     class Base
       include Capistrano::DSL
 
+      HOSTNAME_TYPES = %w(public_ip_address public_dns_name private_ip_address private_dns_name).freeze
+      DEFAULT_HOSTNAME_TYPE = 'public_dns_name'.freeze
+
       attr_reader :aws_counterpart
 
       def aws_client(namespace = aws_namespace)
@@ -29,6 +32,10 @@ module Elbas
 
       def aws_region
         fetch :aws_region
+      end
+
+      def elbas_hostname_type
+        HOSTNAME_TYPES.include?(fetch(:elbas_hostname_type)) ? fetch(:elbas_hostname_type) : DEFAULT_HOSTNAME_TYPE
       end
 
       def self.aws_client(namespace = aws_namespace)

--- a/lib/elbas/aws/instance.rb
+++ b/lib/elbas/aws/instance.rb
@@ -5,15 +5,15 @@ module Elbas
 
       attr_reader :aws_counterpart, :id, :state
 
-      def initialize(id, public_dns, state)
+      def initialize(id, hostname, state)
         @id = id
-        @public_dns = public_dns
+        @hostname = hostname
         @state = state
         @aws_counterpart = aws_namespace::Instance.new id, client: aws_client
       end
 
       def hostname
-        @public_dns
+        @hostname
       end
 
       def running?

--- a/lib/elbas/aws/instance_collection.rb
+++ b/lib/elbas/aws/instance_collection.rb
@@ -8,7 +8,7 @@ module Elbas
       def initialize(ids)
         @ids = ids
         @instances = query_instances_by_ids(ids).map do |i|
-          Instance.new(i.instance_id, i.public_dns_name, i.state.code)
+          Instance.new(i.instance_id, i.send(elbas_hostname_type), i.state.code)
         end
       end
 


### PR DESCRIPTION
Adding the "elbas_hostname_type" variable to specify which of the following hostname formats is to be used when communicating with instances: public_ip_address, public_dns_name, private_ip_address, private_dns_name