### PR TITLE
Support Multiple Auto Scaling Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ the name of your AutoScale group instead of a hostname:
 autoscale 'my-autoscale-group', user: 'apps', roles: [:app, :web, :db]
 ```
 
+If you have multiple autoscaling groups to deploy to, specify each of them:
+
+```ruby
+autoscale 'app-autoscale-group', user: 'apps', roles: [:app, :web]
+autoscale 'worker-autoscale-group', user: 'apps', roles: [:worker]
+```
+
 Run `cap production deploy`.
 
 **As of version 3, your AWS setup must use launch templates as opposed to launch

--- a/lib/elbas/capistrano.rb
+++ b/lib/elbas/capistrano.rb
@@ -6,11 +6,12 @@ def autoscale(groupname, properties = {})
   include Capistrano::DSL
   include Elbas::Logger
 
-  set :aws_autoscale_group_name, groupname
+  set :aws_autoscale_group_names, Array(fetch(:aws_autoscale_group_names)).push(groupname)
 
   asg = Elbas::AWS::AutoscaleGroup.new groupname
   instances = asg.instances.running
 
+  info "Auto Scaling Group: #{groupname}"
   instances.each.with_index do |instance, i|
     info "Adding server: #{instance.hostname}"
 

--- a/lib/elbas/tasks/elbas.rake
+++ b/lib/elbas/tasks/elbas.rake
@@ -12,24 +12,27 @@ namespace :elbas do
   end
 
   task :deploy do
-    asg = Elbas::AWS::AutoscaleGroup.new fetch(:aws_autoscale_group_name)
+    fetch(:aws_autoscale_group_names).each do |aws_autoscale_group_name|
+      info "Auto Scaling Group: #{aws_autoscale_group_name}"
+      asg = Elbas::AWS::AutoscaleGroup.new aws_autoscale_group_name
 
-    info "Creating AMI from a running instance..."
-    ami = Elbas::AWS::AMI.create asg.instances.running.sample
-    ami.tag 'ELBAS-Deploy-group', asg.name
-    ami.tag 'ELBAS-Deploy-id', env.timestamp.to_i.to_s
-    info  "Created AMI: #{ami.id}"
+      info "Creating AMI from a running instance..."
+      ami = Elbas::AWS::AMI.create asg.instances.running.sample
+      ami.tag 'ELBAS-Deploy-group', asg.name
+      ami.tag 'ELBAS-Deploy-id', env.timestamp.to_i.to_s
+      info  "Created AMI: #{ami.id}"
 
-    info "Updating launch template with the new AMI..."
-    launch_template = asg.launch_template.update ami
-    info "Updated launch template, new default version = #{launch_template.version}"
+      info "Updating launch template with the new AMI..."
+      launch_template = asg.launch_template.update ami
+      info "Updated launch template, new default version = #{launch_template.version}"
 
-    info "Cleaning up old AMIs..."
-    ami.ancestors.each do |ancestor|
-      info "Deleting old AMI: #{ancestor.id}"
-      ancestor.delete
+      info "Cleaning up old AMIs..."
+      ami.ancestors.each do |ancestor|
+        info "Deleting old AMI: #{ancestor.id}"
+        ancestor.delete
+      end
+
+      info "Deployment complete!"
     end
-
-    info "Deployment complete!"
   end
 end


### PR DESCRIPTION
Allow multiple "autoscale" declarations. 

I, too, manage two different production autoscale groups -- one for the app servers and one for the background job worker servers.

This change now stores an array of autoscaling groups, which will be iterated through as part of the elbas:deploy task.

Fixes #41.