### PR TITLE
Update default version of launch template

### DIFF
--- a/lib/elbas/aws/launch_template.rb
+++ b/lib/elbas/aws/launch_template.rb
@@ -16,10 +16,15 @@ module Elbas
           source_version: self.version
         }).launch_template_version
 
+        response = aws_client.modify_launch_template({
+          default_version: latest.version_number.to_s,
+          launch_template_id: latest.launch_template_id
+        })
+
         self.class.new(
-          latest&.launch_template_id,
-          latest&.launch_template_name,
-          latest&.version_number
+          response&.launch_template_id,
+          response&.launch_template_name,
+          response&.version_number
         )
       end
 


### PR DESCRIPTION
`create_launch_template_version` doesn't update default version of launch template. But at logger info we can see:
```bash
[ELBAS] Updating launch template with the new AMI...
[ELBAS] Updated launch template, new default version = 14
```
It is not true. I've added this PR to fix it :)