### PR TITLE
Set new launch template version as default after update

### DIFF
--- a/lib/elbas/aws/launch_template.rb
+++ b/lib/elbas/aws/launch_template.rb
@@ -16,6 +16,11 @@ module Elbas
           source_version: self.version
         }).launch_template_version
 
+        aws_client.modify_launch_template({
+          launch_template_id: self.id,
+          default_version: latest.version_number.to_s
+        })
+
         self.class.new(
           latest&.launch_template_id,
           latest&.launch_template_name,

--- a/lib/elbas/tasks/elbas.rake
+++ b/lib/elbas/tasks/elbas.rake
@@ -11,6 +11,14 @@ namespace :elbas do
     end
   end
 
+  task :info do
+    info "Getting ELBAS info..."
+    fetch(:aws_autoscale_group_names).each do |aws_autoscale_group_name|
+      asg = Elbas::AWS::AutoscaleGroup.new aws_autoscale_group_name
+      info "Autoscaling group is #{asg.inspect}"
+    end
+  end
+
   task :deploy do
     fetch(:aws_autoscale_group_names).each do |aws_autoscale_group_name|
       info "Auto Scaling Group: #{aws_autoscale_group_name}"

--- a/lib/elbas/tasks/elbas.rake
+++ b/lib/elbas/tasks/elbas.rake
@@ -36,8 +36,8 @@ namespace :elbas do
 
       info "Cleaning up old AMIs..."
       ami.ancestors.each do |ancestor|
-        info "Deleting old AMI: #{ancestor.id}"
-        ancestor.delete
+        info "Deleting old AMI: #{ancestor.id} [DISABLED]"
+        # ancestor.delete
       end
 
       info "Deployment complete!"


### PR DESCRIPTION
The update method created a new launch template version with the new AMI but never moved $Default to it, so AutoScaling groups pinned to $Default kept launching the previous AMI. Add a modify_launch_template call to promote the new version to default.